### PR TITLE
Improve scripts

### DIFF
--- a/cleanup_swarm.sh
+++ b/cleanup_swarm.sh
@@ -1,8 +1,3 @@
 #!/bin/bash
-docker-machine rm mh-keystore
-docker-machine rm swarm-master
-docker-machine rm swarm-node-01
-docker-machine rm swarm-node-02
-docker-machine rm swarm-node-03
-docker-machine rm swarm-node-04
-docker-machine rm swarm-node-05
+
+docker-machine rm -y mh-keystore swarm-master swarm-node-0{1,2,3,4,5}

--- a/init_swarm.sh
+++ b/init_swarm.sh
@@ -1,16 +1,13 @@
 #!/bin/bash
-# initialize docker
-echo "----- Initialize environment -----"
-eval $(docker-machine env default)
+
+set -e
 
 # create network
 echo "----- Setup machine to deploy the key-value store -----"
 docker-machine create -d virtualbox mh-keystore
 
 echo "----- Start consul -----"
-docker $(docker-machine config mh-keystore) run -d -p "8500:8500" -h "consul" progrium/consul -server -bootstrap
-
-eval $(docker-machine env mh-keystore)
+docker $(docker-machine config mh-keystore) run -d -p "8500:8500" --name="consul" -h "consul" progrium/consul -server -bootstrap
 
 echo "----- create a machine with the swarm master -----"
 docker-machine create -d virtualbox --swarm --swarm-master \
@@ -70,5 +67,3 @@ echo " "
 echo "---- ---------------- -----"
 echo "---- Ready to deploy  -----"
 echo "---- ---------------- -----"
-
-

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -14,11 +14,11 @@ To deploy your cluster, use:
 
 You'll see logs from all the containers being deployed.
 
-Modify your `.kube/config` to point to your kubernetes cluster. To do this, type `docker ps` and fetch the IP and port exposed from the `apiserver`.
-
 You can then list nodes using:
 
-`kubectl get nodes`
+`kubectl -s $(docker port apiserver 8080) get nodes`
+
+You can omit the `-s` flag if you modify your `kube/config` to point to your kubernetes cluster.
 
 ## Scale
 


### PR DESCRIPTION
- Simplify cleanup script
- Use `docker port`
- Remove redundant `docker-machine env`
- Bash strict mode
- Give a name to consul container. This makes it easier to restart it

Signed-off-by: David Gageot david@gageot.net
